### PR TITLE
Typing fixes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,11 +4,11 @@ from setuptools import find_packages, setup
 VERSION="1.0.0"
 
 REQUIRED = [
-    'mypy-extensions',
     'six',
     'pyflakes',
     'pycodestyle',
     'typing',
+    'typing-extensions',
 ]
 
 def long_description():

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,9 @@ setup(
     python_requires='>=2.7.0',
     url='https://github.com/zulip/zulint',
     packages=find_packages(exclude=('tests',)),
+    package_data={
+        'zulint': ["py.typed"],
+    },
     install_requires=REQUIRED,
     license='Apache License 2.0',
     classifiers=[

--- a/tools/run-mypy
+++ b/tools/run-mypy
@@ -6,7 +6,7 @@ import argparse
 import subprocess
 
 from zulint import lister
-from typing import cast, Dict, List
+from typing import List
 
 EXCLUDE_FILES = []  # type: List[str]
 
@@ -57,13 +57,13 @@ parser.add_argument('--quick', action='store_true', default=False,
 
 args = parser.parse_args()
 
-files_dict = cast(Dict[str, List[str]],
-                  lister.list_files(targets=args.targets, ftypes=['py'],
-                                    use_shebang=True,
-                                    modified_only=args.modified,
-                                    group_by_ftype=True,
-                                    exclude=EXCLUDE_FILES,
-                                    ))
+files_dict = lister.list_files(
+    targets=args.targets, ftypes=['py'],
+    use_shebang=True,
+    modified_only=args.modified,
+    group_by_ftype=True,
+    exclude=EXCLUDE_FILES,
+)
 
 
 pyi_files = set(files_dict['pyi'])

--- a/zulint/command.py
+++ b/zulint/command.py
@@ -9,11 +9,9 @@ import os
 import subprocess
 import sys
 
-from typing import cast, Dict, List
-
 MYPY = False
 if MYPY:
-    from typing import Callable, Optional, NoReturn
+    from typing import Callable, Dict, List, Optional, NoReturn
 
 from zulint.printer import print_err, colors, BOLDRED, BLUE, GREEN, ENDC
 from zulint import lister
@@ -90,8 +88,8 @@ class LinterConfig:
         self.by_lang = {}  # type: Dict[str, List[str]]
         self.groups = {}  # type: Dict[str, List[str]]
 
-    def list_files(self, file_types=[], groups={}, use_shebang=True, group_by_ftype=True, exclude=[]):
-        # type: (List[str], Dict[str, List[str]], bool, bool, List[str]) -> Dict[str, List[str]]
+    def list_files(self, file_types=[], groups={}, use_shebang=True, exclude=[]):
+        # type: (List[str], Dict[str, List[str]], bool, List[str]) -> Dict[str, List[str]]
         assert file_types or groups, "Atleast one of `file_types` or `groups` must be specified."
 
         self.groups = groups
@@ -100,11 +98,11 @@ class LinterConfig:
         else:
             file_types.extend({ft for group in groups.values() for ft in group})
 
-
-        self.by_lang = cast(Dict[str, List[str]],
-                            lister.list_files(self.args.targets, modified_only=self.args.modified,
-                                        ftypes=file_types, use_shebang=use_shebang,
-                                        group_by_ftype=group_by_ftype, exclude=exclude))
+        self.by_lang = lister.list_files(
+            targets=self.args.targets, modified_only=self.args.modified,
+            ftypes=file_types, use_shebang=use_shebang,
+            group_by_ftype=True, exclude=exclude,
+        )
         return self.by_lang
 
     def lint(self, func):

--- a/zulint/custom_rules.py
+++ b/zulint/custom_rules.py
@@ -11,7 +11,7 @@ from zulint.printer import print_err, colors, GREEN, ENDC, MAGENTA, BLUE, YELLOW
 MYPY = False
 if MYPY:
     from typing import Dict, List, Optional, Set, Tuple
-    from mypy_extensions import TypedDict
+    from typing_extensions import TypedDict
 
     Rule = TypedDict("Rule", {
         "bad_lines": List[str],

--- a/zulint/custom_rules.py
+++ b/zulint/custom_rules.py
@@ -31,9 +31,9 @@ if MYPY:
 class RuleList:
     """Defines and runs custom linting rules for the specified language."""
 
-    def __init__(self, langs, rules, max_length=None, length_exclude=[], shebang_rules=[],
+    def __init__(self, langs, rules, max_length=None, length_exclude=set(), shebang_rules=[],
                  exclude_files_in=None):
-        # type: (List[str], List[Rule], Optional[int], List[str], List[Rule], Optional[str]) -> None
+        # type: (List[str], List[Rule], Optional[int], Set[str], List[Rule], Optional[str]) -> None
         self.langs = langs
         self.rules = rules
         self.max_length = max_length

--- a/zulint/linters.py
+++ b/zulint/linters.py
@@ -36,7 +36,8 @@ def run_pyflakes(files, options, suppress_patterns=[]):
     color = next(colors)
     pyflakes = subprocess.Popen(['pyflakes'] + files,
                                 stdout=subprocess.PIPE,
-                                stderr=subprocess.PIPE)
+                                stderr=subprocess.PIPE,
+                                universal_newlines=True)
     assert pyflakes.stdout is not None  # Implied by use of subprocess.PIPE
 
     def suppress_line(line):

--- a/zulint/lister.py
+++ b/zulint/lister.py
@@ -9,10 +9,12 @@ import re
 from collections import defaultdict
 import argparse
 from six.moves import filter
+from typing import overload
 
 MYPY = False
 if MYPY:
     from typing import Union, List, Dict
+    from typing_extensions import Literal
 
 def get_ftype(fpath, use_shebang):
     # type: (str, bool) -> str
@@ -43,10 +45,24 @@ def get_ftype(fpath, use_shebang):
     else:
         return ''
 
-def list_files(targets=[], ftypes=[], use_shebang=True,
-               modified_only=False, exclude=[], group_by_ftype=False,
+@overload
+def list_files(group_by_ftype=False, targets=[], ftypes=[], use_shebang=True,
+               modified_only=False, exclude=[],
                extless_only=False):
-    # type: (List[str], List[str], bool, bool, List[str], bool, bool) -> Union[Dict[str, List[str]], List[str]]
+    # type: (Literal[False], List[str], List[str], bool, bool, List[str], bool) -> List[str]
+    ...
+
+@overload
+def list_files(group_by_ftype, targets=[], ftypes=[], use_shebang=True,
+               modified_only=False, exclude=[],
+               extless_only=False):
+    # type: (Literal[True], List[str], List[str], bool, bool, List[str], bool) -> Dict[str, List[str]]
+    ...
+
+def list_files(group_by_ftype=False, targets=[], ftypes=[], use_shebang=True,
+               modified_only=False, exclude=[],
+               extless_only=False):
+    # type: (bool, List[str], List[str], bool, bool, List[str], bool) -> Union[Dict[str, List[str]], List[str]]
     """
     List files tracked by git.
 


### PR DESCRIPTION
~~Do not merge until zulip/zulip#12946 is fixed. Otherwise the backwards-incompatible change to `run_pyflakes` will break Zulip environment provisioning.~~ (Done.)