### PR TITLE
Drop Python 2 support

### DIFF
--- a/example-lint
+++ b/example-lint
@@ -1,14 +1,11 @@
 #!/usr/bin/env python3
 
 import argparse
+from typing import List, Tuple
 
 from zulint.linters import run_pyflakes
 from zulint.command import add_default_linter_arguments, LinterConfig
 from zulint.custom_rules import RuleList
-
-MYPY = False
-if MYPY:
-    from typing import List, Tuple
 
 def run():
     # type: () -> None

--- a/example-lint
+++ b/example-lint
@@ -1,6 +1,4 @@
 #!/usr/bin/env python3
-from __future__ import print_function
-from __future__ import absolute_import
 
 import argparse
 

--- a/example-lint
+++ b/example-lint
@@ -7,8 +7,7 @@ from zulint.linters import run_pyflakes
 from zulint.command import add_default_linter_arguments, LinterConfig
 from zulint.custom_rules import RuleList
 
-def run():
-    # type: () -> None
+def run() -> None:
     parser = argparse.ArgumentParser()
     # Add custom parser arguments here.
 
@@ -31,8 +30,7 @@ def run():
                                   description="Static type checker for Python")
 
     @linter_config.lint
-    def check_custom_rules():
-        # type: () -> int
+    def check_custom_rules() -> int:
         """Check trailing whitespace for specified files"""
         trailing_whitespace_rule = RuleList(
             langs=file_types,
@@ -46,8 +44,7 @@ def run():
         return 1 if failed else 0
 
     @linter_config.lint
-    def pyflakes():
-        # type: () -> int
+    def pyflakes() -> int:
         suppress_patterns = [
             # Error patters in this list will be will not be reported by the linter.
             # syntax: ('File Path', 'Error message')

--- a/setup.py
+++ b/setup.py
@@ -1,19 +1,16 @@
-import io
 from setuptools import find_packages, setup
 
 VERSION="1.0.0"
 
 REQUIRED = [
-    'six',
     'pyflakes',
     'pycodestyle',
-    'typing;python_version<"3.5"',
     'typing-extensions',
 ]
 
 def long_description():
     # type: () -> str
-    with io.open('README.md', encoding='utf8') as f:
+    with open('README.md', encoding='utf8') as f:
         return f.read()
 
 setup(
@@ -24,7 +21,7 @@ setup(
     long_description=long_description(),
     long_description_content_type='text/markdown',
     author_email='zulip-devel@googlegroups.com',
-    python_requires='>=2.7.0',
+    python_requires='>=3.5',
     url='https://github.com/zulip/zulint',
     packages=find_packages(exclude=('tests',)),
     package_data={

--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,7 @@ REQUIRED = [
     'typing-extensions',
 ]
 
-def long_description():
-    # type: () -> str
+def long_description() -> str:
     with open('README.md', encoding='utf8') as f:
         return f.read()
 

--- a/zulint/command.py
+++ b/zulint/command.py
@@ -1,8 +1,3 @@
-# -*- coding: utf-8 -*-
-
-from __future__ import print_function
-from __future__ import absolute_import
-
 import argparse
 import logging
 import os

--- a/zulint/command.py
+++ b/zulint/command.py
@@ -8,8 +8,7 @@ from typing import Callable, Dict, List, Optional, NoReturn
 from zulint.printer import print_err, colors, BOLDRED, BLUE, GREEN, ENDC
 from zulint import lister
 
-def add_default_linter_arguments(parser):
-    # type: (argparse.ArgumentParser) -> None
+def add_default_linter_arguments(parser: argparse.ArgumentParser) -> None:
     parser.add_argument('--modified', '-m',
                         action='store_true',
                         help='Only check modified files')
@@ -45,12 +44,10 @@ def add_default_linter_arguments(parser):
                         action='store_true',
                         help='Automatically fix problems where supported')
 
-def split_arg_into_list(arg):
-    # type: (str) -> List[str]
+def split_arg_into_list(arg: str) -> List[str]:
     return [linter for linter in arg.split(',')]
 
-def run_parallel(lint_functions):
-    # type: (Dict[str, Callable[[], int]]) -> bool
+def run_parallel(lint_functions: Dict[str, Callable[[], int]]) -> bool:
     pids = []
     for name, func in lint_functions.items():
         pid = os.fork()
@@ -74,14 +71,18 @@ class LinterConfig:
     lint_functions = {}  # type: Dict[str, Callable[[], int]]
     lint_descriptions = {}  # type: Dict[str, str]
 
-    def __init__(self, args):
-        # type: (argparse.Namespace) -> None
+    def __init__(self, args: argparse.Namespace) -> None:
         self.args = args
         self.by_lang = {}  # type: Dict[str, List[str]]
         self.groups = {}  # type: Dict[str, List[str]]
 
-    def list_files(self, file_types=[], groups={}, use_shebang=True, exclude=[]):
-        # type: (List[str], Dict[str, List[str]], bool, List[str]) -> Dict[str, List[str]]
+    def list_files(
+        self,
+        file_types: List[str] = [],
+        groups: Dict[str, List[str]] = {},
+        use_shebang: bool = True,
+        exclude: List[str] = [],
+    ) -> Dict[str, List[str]]:
         assert file_types or groups, "Atleast one of `file_types` or `groups` must be specified."
 
         self.groups = groups
@@ -97,15 +98,20 @@ class LinterConfig:
         )
         return self.by_lang
 
-    def lint(self, func):
-        # type: (Callable[[], int]) -> Callable[[], int]
+    def lint(self, func: Callable[[], int]) -> Callable[[], int]:
         self.lint_functions[func.__name__] = func
         self.lint_descriptions[func.__name__] = func.__doc__ if func.__doc__ else "External Linter"
         return func
 
-    def external_linter(self, name, command, target_langs=[], pass_targets=True, fix_arg=None,
-                        description="External Linter"):
-        # type: (str, List[str], List[str], bool, Optional[str], str) -> None
+    def external_linter(
+        self,
+        name: str,
+        command: List[str],
+        target_langs: List[str] = [],
+        pass_targets: bool = True,
+        fix_arg: Optional[str] = None,
+        description: str = "External Linter",
+    ) -> None:
         """Registers an external linter program to be run as part of the
         linter.  This program will be passed the subset of files being
         linted that have extensions in target_langs.  If there are no
@@ -116,8 +122,7 @@ class LinterConfig:
         self.lint_descriptions[name] = description
         color = next(colors)
 
-        def run_linter():
-            # type: () -> int
+        def run_linter() -> int:
             targets = []  # type: List[str]
             if len(target_langs) != 0:
                 targets = [target for lang in target_langs for target in self.by_lang[lang]]
@@ -147,8 +152,7 @@ class LinterConfig:
 
         self.lint_functions[name] = run_linter
 
-    def set_logger(self):
-        # type: () -> None
+    def set_logger(self) -> None:
         logging.basicConfig(format="%(asctime)s %(message)s")
         logger = logging.getLogger()
         if self.args.verbose_timing:
@@ -156,8 +160,7 @@ class LinterConfig:
         else:
             logger.setLevel(logging.WARNING)
 
-    def do_lint(self):
-        # type: () -> NoReturn
+    def do_lint(self) -> NoReturn:
         assert not self.args.only or not self.args.skip, "Only one of --only or --skip can be used at once."
         if self.args.only:
             self.lint_functions = {linter: self.lint_functions[linter] for linter in self.args.only}

--- a/zulint/command.py
+++ b/zulint/command.py
@@ -3,10 +3,7 @@ import logging
 import os
 import subprocess
 import sys
-
-MYPY = False
-if MYPY:
-    from typing import Callable, Dict, List, Optional, NoReturn
+from typing import Callable, Dict, List, Optional, NoReturn
 
 from zulint.printer import print_err, colors, BOLDRED, BLUE, GREEN, ENDC
 from zulint import lister

--- a/zulint/custom_rules.py
+++ b/zulint/custom_rules.py
@@ -1,8 +1,3 @@
-# -*- coding: utf-8 -*-
-
-from __future__ import print_function
-from __future__ import absolute_import
-
 import re
 import traceback
 

--- a/zulint/custom_rules.py
+++ b/zulint/custom_rules.py
@@ -23,9 +23,17 @@ LineTup = Tuple[int, str, str, str]
 class RuleList:
     """Defines and runs custom linting rules for the specified language."""
 
-    def __init__(self, langs, rules, max_length=None, length_exclude=set(), shebang_rules=[],
-                 exclude_files_in=None, exclude_max_length_fns=[], exclude_max_length_line_patterns=[]):
-        # type: (List[str], List[Rule], Optional[int], Set[str], List[Rule], Optional[str], List[str], List[str]) -> None
+    def __init__(
+        self,
+        langs: List[str],
+        rules: List[Rule],
+        max_length: Optional[int] = None,
+        length_exclude: Set[str] = set(),
+        shebang_rules: List[Rule] = [],
+        exclude_files_in: Optional[str] = None,
+        exclude_max_length_fns: List[str] = [],
+        exclude_max_length_line_patterns: List[str] = [],
+    ) -> None:
         self.langs = langs
         self.rules = rules
         self.max_length = max_length
@@ -40,8 +48,7 @@ class RuleList:
         self.exclude_max_length_fns = exclude_max_length_fns
         self.exclude_max_length_line_patterns = exclude_max_length_line_patterns
 
-    def get_line_info_from_file(self, fn):
-        # type: (str) -> List[LineTup]
+    def get_line_info_from_file(self, fn: str) -> List[LineTup]:
         line_tups = []
         for i, line in enumerate(open(fn)):
             line_newline_stripped = line.strip('\n')
@@ -52,8 +59,7 @@ class RuleList:
             line_tups.append(tup)
         return line_tups
 
-    def get_rules_applying_to_fn(self, fn, rules):
-        # type: (str, List[Rule]) -> List[Rule]
+    def get_rules_applying_to_fn(self, fn: str, rules: List[Rule]) -> List[Rule]:
         rules_to_apply = []
         for rule in rules:
             excluded = False
@@ -74,13 +80,14 @@ class RuleList:
 
         return rules_to_apply
 
-    def check_file_for_pattern(self,
-                               fn,
-                               line_tups,
-                               identifier,
-                               color,
-                               rule):
-        # type: (str, List[LineTup], str, str, Rule) -> bool
+    def check_file_for_pattern(
+        self,
+        fn: str,
+        line_tups: List[LineTup],
+        identifier: str,
+        color: str,
+        rule: Rule,
+    ) -> bool:
 
         '''
         DO NOT MODIFY THIS FUNCTION WITHOUT PROFILING.
@@ -131,8 +138,15 @@ class RuleList:
 
         return ok
 
-    def print_error(self, rule, line, identifier, color, fn, line_number):
-        # type: (Rule, str, str, str, str, int) -> None
+    def print_error(
+        self,
+        rule: Rule,
+        line: str,
+        identifier: str,
+        color: str,
+        fn: str,
+        line_number: int,
+    ) -> None:
         print_err(identifier, color, '{} {}at {} line {}:'.format(
             YELLOW + rule['description'], BLUE, fn, line_number))
         print_err(identifier, color, line)
@@ -145,11 +159,12 @@ class RuleList:
                     (YELLOW + " | " + MAGENTA).join(rule['bad_lines']), ENDC))
             print_err(identifier, color, "")
 
-    def check_file_for_long_lines(self,
-                                  fn,
-                                  max_length,
-                                  line_tups):
-        # type: (str, int, List[LineTup]) -> bool
+    def check_file_for_long_lines(
+        self,
+        fn: str,
+        max_length: int,
+        line_tups: List[LineTup]
+    ) -> bool:
         ok = True
         for (i, line, line_newline_stripped, line_fully_stripped) in line_tups:
             if isinstance(line, bytes):
@@ -163,12 +178,13 @@ class RuleList:
                 ok = False
         return ok
 
-    def custom_check_file(self,
-                          fn,
-                          identifier,
-                          color,
-                          max_length=None):
-        # type: (str, str, str, Optional[int]) -> bool
+    def custom_check_file(
+        self,
+        fn: str,
+        identifier: str,
+        color: str,
+        max_length: Optional[int] = None,
+    ) -> bool:
         failed = False
 
         line_tups = self.get_line_info_from_file(fn=fn)
@@ -216,8 +232,7 @@ class RuleList:
 
         return failed
 
-    def check(self, by_lang, verbose=False):
-        # type: (Dict[str, List[str]], bool) -> bool
+    def check(self, by_lang: Dict[str, List[str]], verbose: bool = False) -> bool:
         # By default, a rule applies to all files within the extension for
         # which it is specified (e.g. all .py files)
         # There are three operators we can use to manually include or exclude files from linting for a rule:

--- a/zulint/custom_rules.py
+++ b/zulint/custom_rules.py
@@ -1,26 +1,23 @@
 import re
 import traceback
+from typing import Dict, List, Optional, Set, Tuple
+from typing_extensions import TypedDict
 
 from zulint.printer import print_err, colors, GREEN, ENDC, MAGENTA, BLUE, YELLOW
 
-MYPY = False
-if MYPY:
-    from typing import Dict, List, Optional, Set, Tuple
-    from typing_extensions import TypedDict
-
-    Rule = TypedDict("Rule", {
-        "bad_lines": List[str],
-        "description": str,
-        "exclude": Set[str],
-        "exclude_line": Set[Tuple[str, str]],
-        "exclude_pattern": str,
-        "good_lines": List[str],
-        "include_only": Set[str],
-        "pattern": str,
-        "strip": str,
-        "strip_rule": str,
-    }, total=False)
-    LineTup = Tuple[int, str, str, str]
+Rule = TypedDict("Rule", {
+    "bad_lines": List[str],
+    "description": str,
+    "exclude": Set[str],
+    "exclude_line": Set[Tuple[str, str]],
+    "exclude_pattern": str,
+    "good_lines": List[str],
+    "include_only": Set[str],
+    "pattern": str,
+    "strip": str,
+    "strip_rule": str,
+}, total=False)
+LineTup = Tuple[int, str, str, str]
 
 
 class RuleList:

--- a/zulint/linters.py
+++ b/zulint/linters.py
@@ -1,6 +1,3 @@
-from __future__ import print_function
-from __future__ import absolute_import
-
 import argparse
 import subprocess
 

--- a/zulint/linters.py
+++ b/zulint/linters.py
@@ -5,8 +5,7 @@ from typing import List, Tuple
 from zulint.printer import print_err, colors
 
 
-def run_pycodestyle(files, ignored_rules):
-    # type: (List[str], List[str]) -> bool
+def run_pycodestyle(files: List[str], ignored_rules: List[str]) -> bool:
     if len(files) == 0:
         return False
 
@@ -22,8 +21,11 @@ def run_pycodestyle(files, ignored_rules):
     return failed
 
 
-def run_pyflakes(files, options, suppress_patterns=[]):
-    # type: (List[str], argparse.Namespace, List[Tuple[str, str]]) -> bool
+def run_pyflakes(
+    files: List[str],
+    options: argparse.Namespace,
+    suppress_patterns: List[Tuple[str, str]] = [],
+) -> bool:
     if len(files) == 0:
         return False
     failed = False
@@ -37,8 +39,7 @@ def run_pyflakes(files, options, suppress_patterns=[]):
     assert pyflakes.stdout is not None
     assert pyflakes.stderr is not None
 
-    def suppress_line(line):
-        # type: (str) -> bool
+    def suppress_line(line: str) -> bool:
         for file_pattern, line_pattern in suppress_patterns:
             if file_pattern in line and line_pattern in line:
                 return True

--- a/zulint/linters.py
+++ b/zulint/linters.py
@@ -1,9 +1,6 @@
 import argparse
 import subprocess
-
-MYPY = False
-if MYPY:
-    from typing import List, Tuple
+from typing import List, Tuple
 
 from zulint.printer import print_err, colors
 

--- a/zulint/lister.py
+++ b/zulint/lister.py
@@ -6,12 +6,8 @@ import subprocess
 import re
 from collections import defaultdict
 import argparse
-from typing import overload
-
-MYPY = False
-if MYPY:
-    from typing import Union, List, Dict
-    from typing_extensions import Literal
+from typing import Union, List, Dict, overload
+from typing_extensions import Literal
 
 def get_ftype(fpath, use_shebang):
     # type: (str, bool) -> str

--- a/zulint/lister.py
+++ b/zulint/lister.py
@@ -9,8 +9,7 @@ import argparse
 from typing import Union, List, Dict, overload
 from typing_extensions import Literal
 
-def get_ftype(fpath, use_shebang):
-    # type: (str, bool) -> str
+def get_ftype(fpath: str, use_shebang: bool) -> str:
     ext = os.path.splitext(fpath)[1]
     if ext:
         return ext[1:]
@@ -39,23 +38,37 @@ def get_ftype(fpath, use_shebang):
         return ''
 
 @overload
-def list_files(group_by_ftype=False, targets=[], ftypes=[], use_shebang=True,
-               modified_only=False, exclude=[],
-               extless_only=False):
-    # type: (Literal[False], List[str], List[str], bool, bool, List[str], bool) -> List[str]
+def list_files(
+    group_by_ftype: Literal[False] = False,
+    targets: List[str] = [],
+    ftypes: List[str] = [],
+    use_shebang: bool = True,
+    modified_only: bool = False,
+    exclude: List[str] = [],
+    extless_only: bool = False,
+) -> List[str]:
     ...
 
 @overload
-def list_files(group_by_ftype, targets=[], ftypes=[], use_shebang=True,
-               modified_only=False, exclude=[],
-               extless_only=False):
-    # type: (Literal[True], List[str], List[str], bool, bool, List[str], bool) -> Dict[str, List[str]]
+def list_files(
+    group_by_ftype: Literal[True],
+    targets: List[str] = [],
+    ftypes: List[str] = [],
+    use_shebang: bool = True,
+    modified_only: bool = False, exclude: List[str] = [],
+    extless_only: bool = False,
+) -> Dict[str, List[str]]:
     ...
 
-def list_files(group_by_ftype=False, targets=[], ftypes=[], use_shebang=True,
-               modified_only=False, exclude=[],
-               extless_only=False):
-    # type: (bool, List[str], List[str], bool, bool, List[str], bool) -> Union[Dict[str, List[str]], List[str]]
+def list_files(
+    group_by_ftype: bool = False,
+    targets: List[str] = [],
+    ftypes: List[str] = [],
+    use_shebang: bool = True,
+    modified_only: bool = False,
+    exclude: List[str] = [],
+    extless_only: bool = False,
+) -> Union[Dict[str, List[str]], List[str]]:
     """
     List files tracked by git.
 

--- a/zulint/lister.py
+++ b/zulint/lister.py
@@ -1,6 +1,4 @@
 #!/usr/bin/env python3
-from __future__ import print_function
-from __future__ import absolute_import
 
 import os
 import sys
@@ -8,7 +6,6 @@ import subprocess
 import re
 from collections import defaultdict
 import argparse
-from six.moves import filter
 from typing import overload
 
 MYPY = False

--- a/zulint/printer.py
+++ b/zulint/printer.py
@@ -1,6 +1,3 @@
-from __future__ import print_function
-from __future__ import absolute_import
-
 import sys
 from itertools import cycle
 

--- a/zulint/printer.py
+++ b/zulint/printer.py
@@ -1,9 +1,6 @@
 import sys
 from itertools import cycle
-
-MYPY = False
-if MYPY:
-    from typing import Union, Text
+from typing import Union, Text
 
 # Terminal Color codes for use in differentiatng linters
 BOLDRED = '\x1B[1;31m'

--- a/zulint/printer.py
+++ b/zulint/printer.py
@@ -13,8 +13,7 @@ ENDC = '\033[0m'
 
 colors = cycle([GREEN, YELLOW, BLUE, MAGENTA, CYAN])
 
-def print_err(name, color, line):
-    # type: (str, str, Union[Text, bytes]) -> None
+def print_err(name: str, color: str, line: Union[Text, bytes]) -> None:
 
     # Decode with UTF-8 if in Python 3 and `line` is of bytes type.
     # (Python 2 does this automatically)


### PR DESCRIPTION
Python 2 reached end of life at the beginning of 2020.

(Note that zulint can still be used to lint projects with Python 2 code, as long as zulint itself is run in Python 3.)