### PR TITLE
lister: Filter using specified targets.

### DIFF
--- a/zulint/lister.py
+++ b/zulint/lister.py
@@ -96,12 +96,12 @@ def list_files(
                                                '--show-toplevel']).strip().decode('utf-8')
     exclude_abspaths = [os.path.abspath(os.path.join(repository_root, fpath)) for fpath in exclude]
 
-    cmdline = ['git', 'ls-files'] + targets
+    cmdline = ["git", "ls-files", "-z"] + targets
     if modified_only:
         cmdline.append('-m')
 
     files = subprocess.check_output(
-        ["git", "ls-files", "-z"], encoding="utf-8",
+        cmdline, encoding="utf-8",
     ).split("\0")
     assert files.pop() == ""
     # throw away non-files (like symlinks)


### PR DESCRIPTION
35120a2c690e0fa90d6ce1b610a5a3bd62814e63 introduced a regression
which lists all files regardless of the targets specified. We fix it in this
commit by passing the targets too.