### PR TITLE
linters: Fix subprocess call to run on Windows

### DIFF
--- a/zulint/linters.py
+++ b/zulint/linters.py
@@ -16,6 +16,7 @@ def run_command(
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         universal_newlines=True,
+        shell=True,
     ) as p:
         assert p.stdout is not None
         for line in iter(p.stdout.readline, ""):
@@ -51,6 +52,7 @@ def run_pyflakes(
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         universal_newlines=True,
+        shell=True,
     ) as pyflakes:
         # Implied by use of subprocess.PIPE
         assert pyflakes.stdout is not None


### PR DESCRIPTION
Currently, running the linting script gives us this error on Windows:
```
  File "c:\users\qedk\python-zulip-api\zulip-api-py3-venv\src\zulint\zulint\com
mand.py", line 197, in do_lint
    failed = run_parallel(self.lint_functions, jobs)
  File "c:\users\qedk\python-zulip-api\zulip-api-py3-venv\src\zulint\zulint\com
mand.py", line 81, in run_parallel
    for result in map(run_parallel_worker, args):
  File "c:\users\qedk\python-zulip-api\zulip-api-py3-venv\src\zulint\zulint\com
mand.py", line 61, in run_parallel_worker
    result = func()
  File "c:\users\qedk\python-zulip-api\zulip-api-py3-venv\src\zulint\zulint\com
mand.py", line 161, in run_linter
    return run_command(name, color, full_command, suppress_line)
  File "c:\users\qedk\python-zulip-api\zulip-api-py3-venv\src\zulint\zulint\lin
ters.py", line 18, in run_command
    universal_newlines=True,
  File "c:\users\qedk\appdata\local\programs\python\python37\lib\subprocess.py"
, line 800, in __init__
    restore_signals, start_new_session)
  File "c:\users\qedk\appdata\local\programs\python\python37\lib\subprocess.py"
, line 1207, in _execute_child
    startupinfo)
FileNotFoundError: [WinError 2] The system cannot find the file specified
```
This is possibly due to https://bugs.python.org/issue17023 which has been put as WONTFIX. Putting `shell=True` in the subprocess calls should fix it (tested locally).