### PR TITLE
minor: Change encoding to UTF-8 in `open()` calls.

### DIFF
--- a/example-lint
+++ b/example-lint
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import argparse
+import sys
 from typing import List, Tuple
 
 from zulint.command import LinterConfig, add_default_linter_arguments
@@ -27,7 +28,7 @@ def run() -> None:
     ]  # type: List[str]
     by_lang = linter_config.list_files(file_types, exclude=EXCLUDED_FILES)
 
-    linter_config.external_linter('mypy', ['tools/run-mypy'], ['py'], pass_targets=False,
+    linter_config.external_linter('mypy', [sys.executable, 'tools/run-mypy'], ['py'], pass_targets=False,
                                   description="Static type checker for Python")
     linter_config.external_linter('isort', ['isort'], ['py'],
                                   check_arg=['--check-only', '--diff'],

--- a/zulint/custom_rules.py
+++ b/zulint/custom_rules.py
@@ -51,7 +51,7 @@ class RuleList:
 
     def get_line_info_from_file(self, fn: str) -> List[LineTup]:
         line_tups = []
-        with open(fn) as f:
+        with open(fn, encoding='utf8') as f:
             for i, line in enumerate(f):
                 line_newline_stripped = line.strip('\n')
                 line_fully_stripped = line_newline_stripped.strip()

--- a/zulint/lister.py
+++ b/zulint/lister.py
@@ -17,7 +17,7 @@ def get_ftype(fpath: str, use_shebang: bool) -> str:
         return ext[1:]
     elif use_shebang:
         # opening a file may throw an OSError
-        with open(fpath) as f:
+        with open(fpath, encoding='utf8') as f:
             first_line = f.readline()
             if re.search(r'^#!.*\bpython', first_line):
                 return 'py'


### PR DESCRIPTION
This allows zulint to run on Windows.