### PR TITLE
Match patterns in multiline mode; remove max_length, strip, shebang_rules, trailing newline

### DIFF
--- a/example-lint
+++ b/example-lint
@@ -40,7 +40,7 @@ def run() -> None:
         trailing_whitespace_rule = RuleList(
             langs=file_types,
             rules=[{
-                'pattern': r'\s+$',
+                'pattern': r'[\t ]+$',
                 'description': 'Fix trailing whitespace'
             }]
         )

--- a/example-lint
+++ b/example-lint
@@ -41,7 +41,6 @@ def run() -> None:
             langs=file_types,
             rules=[{
                 'pattern': r'\s+$',
-                'strip': '\n',
                 'description': 'Fix trailing whitespace'
             }]
         )

--- a/example-lint
+++ b/example-lint
@@ -42,6 +42,9 @@ def run() -> None:
             rules=[{
                 'pattern': r'[\t ]+$',
                 'description': 'Fix trailing whitespace'
+            }, {
+                'pattern': r'[^\n]\Z',
+                'description': 'Missing trailing newline'
             }]
         )
         failed = trailing_whitespace_rule.check(by_lang, verbose=args.verbose)

--- a/zulint/custom_rules.py
+++ b/zulint/custom_rules.py
@@ -16,7 +16,6 @@ Rule = TypedDict("Rule", {
     "include_only": AbstractSet[str],
     "pattern": str,
     "strip": str,
-    "strip_rule": str,
 }, total=False)
 LineTup = Tuple[int, str, str, str]
 

--- a/zulint/custom_rules.py
+++ b/zulint/custom_rules.py
@@ -151,10 +151,6 @@ class RuleList:
             if not ok:
                 failed = True
 
-        if contents and not contents.endswith("\n"):
-            print("No newline at the end of file. Fix with `sed -i '$a\\' %s`" % (fn,))
-            failed = True
-
         return failed
 
     def check(self, by_lang: Mapping[str, Sequence[str]], verbose: bool = False) -> bool:

--- a/zulint/custom_rules.py
+++ b/zulint/custom_rules.py
@@ -25,12 +25,10 @@ class RuleList:
         self,
         langs: Sequence[str],
         rules: Sequence[Rule],
-        shebang_rules: Sequence[Rule] = [],
         exclude_files_in: Optional[str] = None,
     ) -> None:
         self.langs = langs
         self.rules = rules
-        self.shebang_rules = shebang_rules
         # Exclude the files in this folder from rules
         self.exclude_files_in = "\\"
         self.verbose = False
@@ -152,18 +150,6 @@ class RuleList:
             )
             if not ok:
                 failed = True
-
-        # TODO: Move the below into more of a framework.
-        firstline = (
-            contents[: line_starts[1]] if len(line_starts) > 1 else contents
-        ).strip()
-
-        if firstline:
-            shebang_rules_to_apply = self.get_rules_applying_to_fn(fn=fn, rules=self.shebang_rules)
-            for rule in shebang_rules_to_apply:
-                if re.search(rule['pattern'], firstline):
-                    self.print_error(rule, firstline, identifier, color, fn, 1)
-                    failed = True
 
         if contents and not contents.endswith("\n"):
             print("No newline at the end of file. Fix with `sed -i '$a\\' %s`" % (fn,))


### PR DESCRIPTION
This is faster and more general. Some patterns may need to be adjusted. `max_length` was buggy but is subsumed by a pattern like `^.{81}`; `shebang_rules` are subsumed by multiline patterns starting with `\A`; the trailing newline check is subsumed by a multiline pattern `[^\n]\Z`.

Corresponding zulip PR: zulip/zulip#22071.