### PR TITLE
add unicode error catching

### DIFF
--- a/zulint/custom_rules.py
+++ b/zulint/custom_rules.py
@@ -134,7 +134,12 @@ class RuleList:
         failed = False
 
         with open(fn, encoding="utf8") as f:
-            contents = f.read()
+            try:
+                contents = f.read()
+            except UnicodeDecodeError as e:
+                print(f"unable to process file {fn} due to unicode decode error")
+                print(e)
+                return True
         line_starts = [m.start() for m in re.finditer(r"^.", contents, re.M | re.S)]
 
         rules_to_apply = self.get_rules_applying_to_fn(fn=fn, rules=self.rules)


### PR DESCRIPTION
So i found this when i hit some non unicode files. 

examples of some errors caught with this

this is a rough fix but at least allows tests to complete. without this catch the script would crash
```
unable to process file (path removed) due to unicode decode error
'utf-8' codec can't decode byte 0xa7 in position 195: invalid start byte
unable to process file (path removed) due to unicode decode error
'utf-8' codec can't decode byte 0xa1 in position 33: invalid start byte
```

The script probably shouldnt just assume a file is going to be utf8 encoded