### PR TITLE
Calculate time elapsed using time.perf_counter.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,8 @@ jobs:
           - 3.11
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - run: python -m pip install isort mypy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,11 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - 3.5
-          - 3.6
           - 3.7
           - 3.8
+          - 3.9
+          - "3.10"
+          - 3.11
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/example-lint
+++ b/example-lint
@@ -22,10 +22,10 @@ def run() -> None:
     # eg: file_types = ['py', 'html', 'css', 'js']
     file_types = ['py']
 
-    EXCLUDED_FILES = [
+    EXCLUDED_FILES: List[str] = [
         # No linters will be run on files in this list.
         # eg: 'path/to/file.py'
-    ]  # type: List[str]
+    ]
     by_lang = linter_config.list_files(file_types, exclude=EXCLUDED_FILES)
 
     linter_config.external_linter('mypy', [sys.executable, 'tools/run-mypy'], ['py'], pass_targets=False,
@@ -52,11 +52,11 @@ def run() -> None:
 
     @linter_config.lint
     def pyflakes() -> int:
-        suppress_patterns = [
+        suppress_patterns: List[Tuple[str, str]] = [
             # Error patters in this list will be will not be reported by the linter.
             # syntax: ('File Path', 'Error message')
             # eg: ('path/to/file.py', 'imported but unused')
-        ]  # type: List[Tuple[str, str]]
+        ]
         failed = run_pyflakes(by_lang['py'], args, suppress_patterns)
         return 1 if failed else 0
 

--- a/tools/run-mypy
+++ b/tools/run-mypy
@@ -8,7 +8,7 @@ from typing import List
 
 from zulint import lister
 
-EXCLUDE_FILES = []  # type: List[str]
+EXCLUDE_FILES: List[str] = []
 
 TOOLS_DIR = os.path.dirname(os.path.abspath(__file__))
 os.chdir(os.path.dirname(TOOLS_DIR))

--- a/zulint/command.py
+++ b/zulint/command.py
@@ -2,6 +2,7 @@ import argparse
 import logging
 import multiprocessing
 import sys
+import time
 import weakref
 from typing import Callable, Dict, List, Mapping, NoReturn, Sequence, Set, Tuple, Union
 
@@ -57,9 +58,11 @@ run_parallel_functions = weakref.WeakValueDictionary()  # type: weakref.WeakValu
 def run_parallel_worker(item: Tuple[str, int]) -> Tuple[str, int]:
     name, func_id = item
     func = run_parallel_functions[func_id]
-    logging.info("start " + name)
+    logging.info("start {}".format(name))
+    time_start = time.perf_counter()
     result = func()
-    logging.info("finish " + name)
+    time_end = time.perf_counter()
+    logging.info("finish {}; elapsed time: {}".format(name, time_end - time_start))
     sys.stdout.flush()
     sys.stderr.flush()
     return name, result


### PR DESCRIPTION
This makes --verbose-timing more useful to see which linter is falling behind.