### PR TITLE
custom-rules: Fix string printed for unmatched_exclude_lines.

### DIFF
--- a/zulint/custom_rules.py
+++ b/zulint/custom_rules.py
@@ -100,7 +100,7 @@ class RuleList:
             ok = False
 
         if unmatched_exclude_lines:
-            print("Please remove exclusions for file {fn}: {unmatched_exclude_lines}")
+            print(f"Please remove exclusions for file {fn}: {unmatched_exclude_lines}")
 
         return ok
 


### PR DESCRIPTION
Fixes the string when there are `unmatched_exclude_lines` so that the file name and line in the file are shown in the terminal.

Before:
`Please remove exclusions for file {fn}: {unmatched_exclude_lines}`

After:
`Please remove exclusions for web/src/common.ts: $(this).before($("<kbd>").text("Fn"), $("<span>").text(" + ").contents());`